### PR TITLE
Buffer and Log get overwritten every iteration of the loop

### DIFF
--- a/checkvolumesize
+++ b/checkvolumesize
@@ -33,11 +33,11 @@ EOF
 
 # Parse options
 POSITIONAL=()
+BUFFER=10
+LOG=false
+
 while [[ $# -gt 0 ]]; do
   key="$1"
-
-  BUFFER=10
-  LOG=false
 
   case $key in
       --help|-h|help)


### PR DESCRIPTION
Because BUFFER and LOG are inside the loop each iteration they get set to the initial values, overwriting any value set by the corresponding option if there are later options set.

For example: simply adding `--log` will cause buffer to default to 10 even if some other value had been previously set.